### PR TITLE
updated script.ps1 with updated branch syntax utilizing git switch and correct switch

### DIFF
--- a/Part02MasterGit/Script.ps1
+++ b/Part02MasterGit/Script.ps1
@@ -374,7 +374,7 @@ gitgraph
 #When we switch it also updates the staging and working directory for the checked out branch
 
 #To create and checkout in one step:
-git checkout -c branch1
+git switch -c branch1
 
 #To push a branch to a remote.
 #The -u sets up tracking between local and remote branch. Allows argumentless git pull in future. Will do this later

--- a/Part02MasterGit/dm.csv
+++ b/Part02MasterGit/dm.csv
@@ -1,0 +1,2 @@
+name, alias, power
+Superman, Clark Kent, 100


### PR DESCRIPTION
#To create and checkout in one step:

#Was git checkout -c branch1
 # Should be 'git switch -c branch1' (git checkout utilizes -b) also git switch is the preferred method AFAIK.